### PR TITLE
Add cube spawn ability via Enhanced Input

### DIFF
--- a/Source/SurvivingParadise1/SimpleCubeActor.cpp
+++ b/Source/SurvivingParadise1/SimpleCubeActor.cpp
@@ -1,0 +1,21 @@
+#include "SimpleCubeActor.h"
+#include "Components/SceneComponent.h"
+#include "Components/StaticMeshComponent.h"
+#include "UObject/ConstructorHelpers.h"
+#include "Engine/StaticMesh.h"
+
+ASimpleCubeActor::ASimpleCubeActor()
+{
+    RootScene = CreateDefaultSubobject<USceneComponent>(TEXT("RootScene"));
+    RootComponent = RootScene;
+
+    CubeMesh = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("CubeMesh"));
+    CubeMesh->SetupAttachment(RootScene);
+
+    static ConstructorHelpers::FObjectFinder<UStaticMesh> CubeMeshAsset(TEXT("/Engine/BasicShapes/Cube.Cube"));
+    if (CubeMeshAsset.Succeeded())
+    {
+        CubeMesh->SetStaticMesh(CubeMeshAsset.Object);
+    }
+}
+

--- a/Source/SurvivingParadise1/SimpleCubeActor.h
+++ b/Source/SurvivingParadise1/SimpleCubeActor.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "SimpleCubeActor.generated.h"
+
+UCLASS()
+class ASimpleCubeActor : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    ASimpleCubeActor();
+
+protected:
+    UPROPERTY(VisibleAnywhere, Category="Components")
+    USceneComponent* RootScene;
+
+    UPROPERTY(VisibleAnywhere, Category="Components")
+    UStaticMeshComponent* CubeMesh;
+};
+

--- a/Source/SurvivingParadise1/SurvivingParadise1Character.h
+++ b/Source/SurvivingParadise1/SurvivingParadise1Character.h
@@ -13,6 +13,7 @@ class UCameraComponent;
 class UInputAction;
 class UInputMappingContext;
 struct FInputActionValue;
+class ASimpleCubeActor;
 
 DECLARE_LOG_CATEGORY_EXTERN(LogTemplateCharacter, Log, All);
 
@@ -42,8 +43,16 @@ class ASurvivingParadise1Character : public ACharacter
 	UInputAction* MoveAction;
 
 	/** Look Input Action */
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
-	class UInputAction* LookAction;
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
+        class UInputAction* LookAction;
+
+       /** Action to spawn a cube */
+       UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
+       UInputAction* SpawnCubeAction;
+
+       /** Mapping context for spawning cube */
+       UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
+       UInputMappingContext* SpawnCubeMappingContext;
 	
 public:
 	ASurvivingParadise1Character();
@@ -53,7 +62,10 @@ protected:
 	void Move(const FInputActionValue& Value);
 
 	/** Called for looking input */
-	void Look(const FInputActionValue& Value);
+        void Look(const FInputActionValue& Value);
+
+        /** Spawns a cube actor */
+        void SpawnCube(const FInputActionValue& Value);
 
 protected:
 	// APawn interface


### PR DESCRIPTION
## Summary
- implement `ASimpleCubeActor` with root scene and cube mesh
- bind `SpawnCubeAction` in input component if set
- allow customizing cube action and mapping in the editor
- spawn `ASimpleCubeActor` in front of the player when pressing F

## Testing
- `echo "No tests"`


------
https://chatgpt.com/codex/tasks/task_e_6845d0bb98a0833192b8226faeca4e9b