### PR TITLE
Add ghost crosshair placement

### DIFF
--- a/Source/SurvivingParadise1/GhostCubeActor.cpp
+++ b/Source/SurvivingParadise1/GhostCubeActor.cpp
@@ -1,0 +1,36 @@
+#include "GhostCubeActor.h"
+#include "Components/SceneComponent.h"
+#include "Components/StaticMeshComponent.h"
+#include "UObject/ConstructorHelpers.h"
+#include "Engine/StaticMesh.h"
+#include "Materials/Material.h"
+
+AGhostCubeActor::AGhostCubeActor()
+{
+    RootScene = CreateDefaultSubobject<USceneComponent>(TEXT("RootScene"));
+    RootComponent = RootScene;
+
+    CubeMesh = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("CubeMesh"));
+    CubeMesh->SetupAttachment(RootScene);
+    CubeMesh->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+
+    static ConstructorHelpers::FObjectFinder<UStaticMesh> CubeMeshAsset(TEXT("/Engine/BasicShapes/Cube.Cube"));
+    if (CubeMeshAsset.Succeeded())
+    {
+        CubeMesh->SetStaticMesh(CubeMeshAsset.Object);
+    }
+
+    // Attempt to use a translucent material to visualize the ghost
+    static ConstructorHelpers::FObjectFinder<UMaterial> GhostMat(TEXT("/Engine/EngineMaterials/Widget3DPassThrough.Widget3DPassThrough"));
+    if (GhostMat.Succeeded())
+    {
+        CubeMesh->SetMaterial(0, GhostMat.Object);
+        CubeMesh->SetRenderCustomDepth(true);
+    }
+}
+
+void AGhostCubeActor::MoveGhost(const FVector& Delta)
+{
+    AddActorWorldOffset(Delta, true);
+}
+

--- a/Source/SurvivingParadise1/GhostCubeActor.h
+++ b/Source/SurvivingParadise1/GhostCubeActor.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "GhostCubeActor.generated.h"
+
+UCLASS()
+class AGhostCubeActor : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    AGhostCubeActor();
+
+    /** Moves the ghost actor by the specified delta. */
+    void MoveGhost(const FVector& Delta);
+
+protected:
+    UPROPERTY(VisibleAnywhere, Category="Components")
+    USceneComponent* RootScene;
+
+    UPROPERTY(VisibleAnywhere, Category="Components")
+    UStaticMeshComponent* CubeMesh;
+};
+

--- a/Source/SurvivingParadise1/SurvivingParadise1Character.h
+++ b/Source/SurvivingParadise1/SurvivingParadise1Character.h
@@ -14,6 +14,7 @@ class UInputAction;
 class UInputMappingContext;
 struct FInputActionValue;
 class ASimpleCubeActor;
+class AGhostCubeActor;
 
 DECLARE_LOG_CATEGORY_EXTERN(LogTemplateCharacter, Log, All);
 
@@ -53,6 +54,30 @@ class ASurvivingParadise1Character : public ACharacter
        /** Mapping context for spawning cube */
        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
        UInputMappingContext* SpawnCubeMappingContext;
+
+       /** Action to begin ghost placement */
+       UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
+       UInputAction* StartPlacementAction;
+
+       /** Action to confirm ghost placement */
+       UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
+       UInputAction* ConfirmPlacementAction;
+
+       /** Action to rotate the ghost */
+       UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = Input, meta = (AllowPrivateAccess = "true"))
+       UInputAction* RotatePlacementAction;
+
+       /** Currently spawned placement ghost */
+       UPROPERTY()
+       AGhostCubeActor* PlacementGhost;
+
+       /** Distance to spawn ghost in front of player */
+       UPROPERTY(EditAnywhere, Category = Placement)
+       float PlacementDistance = 200.f;
+
+       /** Degrees to rotate the ghost on each input */
+       UPROPERTY(EditAnywhere, Category = Placement)
+       float RotationStep = 90.f;
 	
 public:
 	ASurvivingParadise1Character();
@@ -67,11 +92,25 @@ protected:
         /** Spawns a cube actor */
         void SpawnCube(const FInputActionValue& Value);
 
+       /** Begin placement by spawning a ghost */
+       void StartPlacement(const FInputActionValue& Value);
+
+       /** Rotate the placement ghost */
+       void RotatePlacement(const FInputActionValue& Value);
+
+       /** Confirm placement and spawn final cube */
+       void ConfirmPlacement(const FInputActionValue& Value);
+
 protected:
-	// APawn interface
-	virtual void NotifyControllerChanged() override;
-	virtual void SetupPlayerInputComponent(UInputComponent* InputComponent) override;
-	// End of APawn interface
+       // APawn interface
+       virtual void NotifyControllerChanged() override;
+       virtual void SetupPlayerInputComponent(UInputComponent* InputComponent) override;
+       // End of APawn interface
+
+       /** Updates the ghost to follow the crosshair */
+       void UpdatePlacementGhost();
+
+       virtual void Tick(float DeltaTime) override;
 
 public:
 	/** Returns Mesh1P subobject **/


### PR DESCRIPTION
## Summary
- refine placement logic so ghost follows crosshair
- allow rotating the ghost with one action
- spawn cube at ghost transform on confirm

## Testing
- `g++ -std=c++17 -c Source/SurvivingParadise1/GhostCubeActor.cpp -I/usr/include -I/usr/local/include` *(fails: `CoreMinimal.h` not found)*
- `g++ -std=c++17 -c Source/SurvivingParadise1/SurvivingParadise1Character.cpp -I/usr/include -I/usr/local/include` *(fails: `CoreMinimal.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d461775c8331bb50b72ff9e34c6d